### PR TITLE
catch error when queried package has no comments

### DIFF
--- a/aur_talk.py
+++ b/aur_talk.py
@@ -28,6 +28,8 @@ def fetch_package_comments(package_name, num_comments):
     except HTTPError:
         print('Package "{}" not found.'.format(package_name))
         exit(1)
+    if not url:
+        return []
     return html.xpath(
         '/html/body/div[2]/div[@class="comments package-comments"]')
 
@@ -67,6 +69,9 @@ def print_package_comments(args):
     '''Fetch and display an AUR package's comments.'''
     comments_sections = fetch_package_comments(args.package_name,
                                                args.num_comments)
+    if len(comments_sections) == 0:
+        print('No comments for this package.')
+        return
     has_pinned_comments = comments_sections[0].xpath(
         'div/h3/span[@class="text"]/text()')[0] == 'Pinned Comments'
     if args.latest_only and len(comments_sections) > 1:


### PR DESCRIPTION
The python version crashed i a special case.
When we queried a package that hasn't got any comments, a `list index out of range` exception was thrown, because `fetch_package_comments()` returned nothing.
This commit takes care of that special case.

Thx a lot for these scripts and the AUR package, btw !  :smile: